### PR TITLE
Supported keyed lists

### DIFF
--- a/packages/grim/bundlesize.json
+++ b/packages/grim/bundlesize.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "./grim.min.js",
-      "maxSize": "1.86 kB"
+      "maxSize": "2.4 kB"
     }
   ]
 }

--- a/packages/grim/test/test-each.js
+++ b/packages/grim/test/test-each.js
@@ -2,70 +2,123 @@ import { stamp } from '../grim.js';
 import { createTemplate } from './helpers.js';
 
 QUnit.module('<template $each=cond>', () => {
-  QUnit.test('Basics', assert => {
-    let raw = createTemplate(`
-      <ul>
-        <template $each="colors"><li>{{item}}</li></template>
-      </ul>
-    `);
-    let template = stamp(raw);
-    let frag = template.createInstance({
-      colors: ['orange', 'red']
+  QUnit.module('Non-keyed', () => {
+    QUnit.test('Basics', assert => {
+      let raw = createTemplate(`
+        <ul>
+          <template $each="colors"><li>{{item}}</li></template>
+        </ul>
+      `);
+      let template = stamp(raw);
+      let frag = template.createInstance({
+        colors: ['orange', 'red']
+      });
+
+      let one = frag.firstElementChild.firstElementChild;
+      assert.equal(one.tagName, 'LI');
+      assert.equal(one.textContent, 'orange');
+
+      let two = one.nextElementSibling;
+      assert.equal(two.tagName, 'LI');
+      assert.equal(two.textContent, 'red');
     });
 
-    let one = frag.firstElementChild.firstElementChild;
-    assert.equal(one.tagName, 'LI');
-    assert.equal(one.textContent, 'orange');
+    QUnit.test('Emptying a list', assert => {
+      let raw = createTemplate(`
+        <ul>
+          <template $each="colors"><li>{{item}}</li></template>
+        </ul>
+      `);
+      let template = stamp(raw);
+      let frag = template.createInstance({
+        colors: ['orange']
+      });
 
-    let two = one.nextElementSibling;
-    assert.equal(two.tagName, 'LI');
-    assert.equal(two.textContent, 'red');
+      let one = frag.firstElementChild.firstElementChild;
+      assert.equal(one.tagName, 'LI');
+      assert.equal(one.textContent, 'orange');
+
+      frag.update({
+        colors: []
+      });
+
+      one = frag.firstElementChild.firstElementChild;
+      assert.equal(one, null, 'There is no element child now');
+    });
   });
 
-  QUnit.test('Emptying a list', assert => {
-    let raw = createTemplate(`
-      <ul>
-        <template $each="colors"><li>{{item}}</li></template>
-      </ul>
-    `);
-    let template = stamp(raw);
-    let frag = template.createInstance({
-      colors: ['orange']
+  QUnit.module('Keyed', () => {
+    QUnit.test('Reuse the correct node', assert => {
+      let raw = createTemplate(`
+        <ul>
+          <template $each="colors" data-key="id"><li><input type="text" .value="item.label"></li></template>
+        </ul>
+      `);
+      let template = stamp(raw);
+      let frag = template.createInstance({
+        colors: [{ id: 1, label: 'orange' }]
+      });
+      let one = frag.firstElementChild.firstElementChild.firstElementChild;
+      one.value = 'testing';
+
+      frag.update({
+        colors: [{ id: 2, label: 'red' }, { id: 1, label: 'orange' }]
+      });
+
+      one = frag.firstElementChild.firstElementChild.firstElementChild;
+      assert.equal(one.value, 'red');
+
+      let two = frag.firstElementChild.firstElementChild.nextElementSibling.firstElementChild;
+      assert.equal(two.value, 'testing');
     });
 
-    let one = frag.firstElementChild.firstElementChild;
-    assert.equal(one.tagName, 'LI');
-    assert.equal(one.textContent, 'orange');
+    QUnit.test('Can insert items in all positions', assert => {
+      let raw = createTemplate(`
+        <ul>
+          <template $each="colors" data-key="id"><li>{{item.label}}</li></template>
+        </ul>
+      `);
+      let template = stamp(raw);
+      let frag = template.createInstance({
+        colors: [{ id: 1, label: 'blue' }]
+      });
+      let ul = frag.firstElementChild;
 
-    frag.update({
-      colors: []
+      frag.update({
+        colors:[
+          { id: 2, label: 'red' },
+          { id: 1, label: 'blue' }
+        ]
+      });
+
+      assert.equal(ul.firstElementChild.textContent, 'red');
+      assert.equal(ul.firstElementChild.nextElementSibling.textContent, 'blue');
+
+      frag.update({
+        colors:[
+          { id: 2, label: 'red' },
+          { id: 3, label: 'purple' },
+          { id: 1, label: 'blue' }
+        ]
+      });
+
+      assert.equal(ul.firstElementChild.textContent, 'red');
+      assert.equal(ul.firstElementChild.nextElementSibling.textContent, 'purple');
+      assert.equal(ul.firstElementChild.nextElementSibling.nextElementSibling.textContent, 'blue');
+
+      frag.update({
+        colors:[
+          { id: 1, label: 'blue' },
+          { id: 2, label: 'red' }
+        ]
+      });
+
+      assert.equal(ul.firstElementChild.textContent, 'blue');
+      assert.equal(ul.firstElementChild.nextElementSibling.textContent, 'red');
+      assert.equal(ul.firstElementChild.nextElementSibling.nextElementSibling, null);
+
+      frag.update({ colors:[] });
+      assert.equal(ul.firstElementChild, null);
     });
-
-    one = frag.firstElementChild.firstElementChild;
-    assert.equal(one, null, 'There is no element child now');
-  });
-
-  QUnit.test('Keyed lists reuse the correct node', assert => {
-    let raw = createTemplate(`
-      <ul>
-        <template $each="colors" data-key="id"><li><input type="text" .value="item.label"></li></template>
-      </ul>
-    `);
-    let template = stamp(raw);
-    let frag = template.createInstance({
-      colors: [{ id: 1, label: 'orange' }]
-    });
-    let one = frag.firstElementChild.firstElementChild.firstElementChild;
-    one.value = 'testing';
-
-    frag.update({
-      colors: [{ id: 2, label: 'red' }, { id: 1, label: 'orange' }]
-    });
-
-    one = frag.firstElementChild.firstElementChild.firstElementChild;
-    assert.equal(one.value, 'red');
-
-    let two = frag.firstElementChild.firstElementChild.nextElementSibling.firstElementChild;
-    assert.equal(two.value, 'testing');
   });
 });

--- a/packages/grim/test/test-each.js
+++ b/packages/grim/test/test-each.js
@@ -43,5 +43,29 @@ QUnit.module('<template $each=cond>', () => {
 
     one = frag.firstElementChild.firstElementChild;
     assert.equal(one, null, 'There is no element child now');
-  })
+  });
+
+  QUnit.test('Keyed lists reuse the correct node', assert => {
+    let raw = createTemplate(`
+      <ul>
+        <template $each="colors" data-key="id"><li><input type="text" .value="item.label"></li></template>
+      </ul>
+    `);
+    let template = stamp(raw);
+    let frag = template.createInstance({
+      colors: [{ id: 1, label: 'orange' }]
+    });
+    let one = frag.firstElementChild.firstElementChild.firstElementChild;
+    one.value = 'testing';
+
+    frag.update({
+      colors: [{ id: 2, label: 'red' }, { id: 1, label: 'orange' }]
+    });
+
+    one = frag.firstElementChild.firstElementChild.firstElementChild;
+    assert.equal(one.value, 'red');
+
+    let two = frag.firstElementChild.firstElementChild.nextElementSibling.firstElementChild;
+    assert.equal(two.value, 'testing');
+  });
 });

--- a/packages/grim/test/test-each.js
+++ b/packages/grim/test/test-each.js
@@ -48,6 +48,26 @@ QUnit.module('<template $each=cond>', () => {
   });
 
   QUnit.module('Keyed', () => {
+    QUnit.test('Sorted in array order', assert => {
+      let raw = createTemplate(`
+        <ul>
+          <template $each="colors" data-key="id"><li>{{item.label}}</li></template>
+        </ul>
+      `);
+      let template = stamp(raw);
+      let frag = template.createInstance({
+        colors: [
+          { id: 1, label: 'red' },
+          { id: 2, label: 'yellow' },
+          { id: 3, label: 'blue' }
+        ]
+      });
+      let ul = frag.firstElementChild;
+      assert.equal(ul.firstElementChild.textContent, 'red');
+      assert.equal(ul.firstElementChild.nextElementSibling.textContent, 'yellow');
+      assert.equal(ul.firstElementChild.nextElementSibling.nextElementSibling.textContent, 'blue');
+    });
+
     QUnit.test('Reuse the correct node', assert => {
       let raw = createTemplate(`
         <ul>
@@ -80,34 +100,20 @@ QUnit.module('<template $each=cond>', () => {
       `);
       let template = stamp(raw);
       let frag = template.createInstance({
-        colors: [{ id: 1, label: 'blue' }]
-      });
-      let ul = frag.firstElementChild;
-
-      frag.update({
-        colors:[
-          { id: 2, label: 'red' },
-          { id: 1, label: 'blue' }
-        ]
-      });
-
-      assert.equal(ul.firstElementChild.textContent, 'red');
-      assert.equal(ul.firstElementChild.nextElementSibling.textContent, 'blue');
-
-      frag.update({
-        colors:[
+        colors: [
           { id: 2, label: 'red' },
           { id: 3, label: 'purple' },
           { id: 1, label: 'blue' }
         ]
       });
+      let ul = frag.firstElementChild;
 
       assert.equal(ul.firstElementChild.textContent, 'red');
       assert.equal(ul.firstElementChild.nextElementSibling.textContent, 'purple');
       assert.equal(ul.firstElementChild.nextElementSibling.nextElementSibling.textContent, 'blue');
 
       frag.update({
-        colors:[
+        colors: [
           { id: 1, label: 'blue' },
           { id: 2, label: 'red' }
         ]


### PR DESCRIPTION
This adds support for keyed lists. Used like so:

```js
<template $each="colors" data-key="id">

</template>
```

In which case the `id` prop is used as a key.